### PR TITLE
Bump major version to 3.x

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '2.0.{build}'
+version: '3.0.{build}'
 skip_tags: true
 image:
 - Visual Studio 2019


### PR DESCRIPTION
We've made some major changes to the internals of the input with the addition of TLS so this PR bumps the package version. This will be reflected in the Docker container and NuGet packages.