### PR TITLE
include sources in error messages and don't overflow on invalid timestamps

### DIFF
--- a/sqelf/src/config.rs
+++ b/sqelf/src/config.rs
@@ -1,7 +1,16 @@
-use std::{env, str::FromStr};
+use std::{
+    env,
+    str::FromStr,
+};
 
 use crate::server::Certificate;
-use crate::{diagnostics, process, receive, server, Error};
+use crate::{
+    diagnostics,
+    process,
+    receive,
+    server,
+    Error,
+};
 
 #[derive(Debug, Default, Clone)]
 pub struct Config {

--- a/sqelf/src/process/clef.rs
+++ b/sqelf/src/process/clef.rs
@@ -83,9 +83,10 @@ impl Timestamp {
         let scaled_fract = fract.to_u32()?;
         let nanos = scaled_fract * 10u32.pow(9 - ts.scale());
 
-        Some(Timestamp(
-            SystemTime::UNIX_EPOCH + Duration::new(secs, nanos),
-        ))
+        // If the timestamp would overflow then return `None`
+        SystemTime::UNIX_EPOCH
+            .checked_add(Duration::new(secs, nanos))
+            .map(Timestamp)
     }
 }
 
@@ -144,5 +145,23 @@ impl<'a> Message<'a> {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_from_decimal() {
+        let ts = Timestamp::from_decimal(Decimal::new(1666223567, 0)).unwrap();
+
+        assert_eq!("\"2022-10-19T23:52:47Z\"", serde_json::to_string(&ts).unwrap());
+    }
+
+    #[test]
+    fn timestamp_from_decimal_overflow() {
+        // Ensure we don't panic on timestamps that are out of range
+        assert!(Timestamp::from_decimal(Decimal::from_i128_with_scale(u64::MAX as i128, 0)).is_none());
     }
 }

--- a/sqelf/src/process/mod.rs
+++ b/sqelf/src/process/mod.rs
@@ -523,4 +523,20 @@ mod tests {
 
         assert!(err.to_string().contains(gelf));
     }
+
+    #[test]
+    fn non_utf8_input_includes_some_raw_content() {
+        let gelf = &"🦫".as_bytes()[0..3];
+
+        let process = Process::new(Config {
+            include_raw_payload: true,
+            ..Default::default()
+        });
+
+        let err = process
+            .with_clef(gelf, |_| unreachable!())
+            .expect_err("expected parsing to fail");
+
+        assert!(err.to_string().contains(&*String::from_utf8_lossy(gelf)));
+    }
 }

--- a/sqelf/src/server/mod.rs
+++ b/sqelf/src/server/mod.rs
@@ -1,20 +1,36 @@
 use std::fs::File;
 use std::io::BufReader;
-use std::{marker::Unpin, str::FromStr, time::Duration};
-
-use futures::{
-    future::{BoxFuture, Either},
-    select, FutureExt, StreamExt,
+use std::{
+    marker::Unpin,
+    str::FromStr,
+    time::Duration,
 };
 
-use tokio::{runtime::Runtime, signal::ctrl_c, sync::oneshot};
+use futures::{
+    future::{
+        BoxFuture,
+        Either,
+    },
+    select,
+    FutureExt,
+    StreamExt,
+};
+
+use tokio::{
+    runtime::Runtime,
+    signal::ctrl_c,
+    sync::oneshot,
+};
 
 use anyhow::Error;
 
 use bytes::Bytes;
 use tokio_rustls::rustls;
 
-use crate::{diagnostics::*, receive::Message};
+use crate::{
+    diagnostics::*,
+    receive::Message,
+};
 
 mod tcp;
 mod udp;
@@ -247,7 +263,7 @@ pub fn build(
                             }
                             Err(err) => {
                                 increment!(server.process_err);
-                                emit_err(&err, "GELF processing failed");
+                                emit_err(err.as_ref(), "GELF processing failed");
                             }
                         }
                     },
@@ -258,13 +274,13 @@ pub fn build(
                     // An error occurred receiving a chunk
                     Some(Ok(Received::Error(err))) => {
                         increment!(server.receive_err);
-                        emit_err(&err, "GELF processing failed");
+                        emit_err(err.as_ref(), "GELF processing failed");
                         continue;
                     }
                     // An unrecoverable error occurred receiving a chunk
                     Some(Err(err)) => {
                         increment!(server.receive_err);
-                        emit_err(&err, "GELF processing failed irrecoverably");
+                        emit_err(err.as_ref(), "GELF processing failed irrecoverably");
                         break;
                     },
                     None => {
@@ -292,7 +308,7 @@ pub fn build(
     Ok(Server {
         fut: Box::pin(async move {
             if let Err(err) = server.await {
-                emit_err(&err, "GELF server failed");
+                emit_err(err.as_ref(), "GELF server failed");
             }
         }),
         handle,

--- a/tests/src/support/mod.rs
+++ b/tests/src/support/mod.rs
@@ -1,4 +1,7 @@
-use byteorder::{BigEndian, ByteOrder};
+use byteorder::{
+    BigEndian,
+    ByteOrder,
+};
 
 const SERVER_HOST: &'static str = "localhost";
 const SERVER_BIND: &'static str = "0.0.0.0:12202";
@@ -63,7 +66,10 @@ pub(crate) fn tcp_delim() -> Vec<Vec<u8>> {
 pub(crate) fn test_child(name: &str) -> bool {
     use std::{
         env,
-        process::{Command, Stdio},
+        process::{
+            Command,
+            Stdio,
+        },
     };
 
     let self_bin = env::args().next().expect("missing self command");

--- a/tests/src/support/server.rs
+++ b/tests/src/support/server.rs
@@ -1,14 +1,24 @@
 use std::{
-    sync::{Arc, Mutex},
+    sync::{
+        Arc,
+        Mutex,
+    },
     thread,
     time::Duration,
 };
 
-use crossbeam_channel::{self, Receiver};
+use crossbeam_channel::{
+    self,
+    Receiver,
+};
 
 use serde_json::Value;
 
-use sqelf::{process, receive, server};
+use sqelf::{
+    process,
+    receive,
+    server,
+};
 
 use super::SERVER_BIND;
 
@@ -70,7 +80,10 @@ impl Builder {
                     .take()
                     .map(|path| server::Certificate {
                         path: path.clone(),
-                        private_key_path: self.tcp_certificate_private_key_path.take().unwrap_or(path),
+                        private_key_path: self
+                            .tcp_certificate_private_key_path
+                            .take()
+                            .unwrap_or(path),
                     }),
                 ..Default::default()
             },

--- a/tests/src/support/tcp.rs
+++ b/tests/src/support/tcp.rs
@@ -3,7 +3,10 @@ use std::convert::TryInto;
 use std::sync::Arc;
 use std::{
     io::Write,
-    net::{self, TcpStream},
+    net::{
+        self,
+        TcpStream,
+    },
 };
 
 use super::SERVER_ADDR;


### PR DESCRIPTION
For #111 and #112

This also includes some noise from formatting changes. There are 2 notable changes in here:

1. Don't panic when timestamps from GELF would overflow when converted into an `Instant`. This can happen if the number sent isn't at second-precision.
2. Include the messages from source errors, not just the top-level one, when GELF processing fails.