### PR TITLE
Add branch name to versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ for:
   - ps: $env:Path = "C:\Users\appveyor\.cargo\bin;$env:Path"
 
   build_script:
-  - ps: ./ci/win-x64/build.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)"
+  - ps: ./ci/win-x64/build.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)" -branch "$($env:APPVEYOR_REPO_BRANCH)"
 
   deploy:
   - provider: NuGet
@@ -45,7 +45,7 @@ for:
   - ps: $env:PATH = "/home/appveyor/.cargo/bin:$env:PATH"
 
   build_script:
-  - ps: ./ci/linux-x64/build.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)"
+  - ps: ./ci/linux-x64/build.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)" -branch "$($env:APPVEYOR_REPO_BRANCH)"
 
 artifacts:
 - path: publish\*

--- a/ci/linux-x64/build.ps1
+++ b/ci/linux-x64/build.ps1
@@ -5,6 +5,10 @@ param (
 $ErrorActionPreference = "Stop"
 Push-Location "$PSScriptRoot/../../"
 
+if ($branch -ne "main") {
+    $shortver = "$shortver-$branch"
+}
+
 . "./ci/build-deps.ps1"
 
 function Invoke-SmokeTest($protocol) {

--- a/ci/linux-x64/build.ps1
+++ b/ci/linux-x64/build.ps1
@@ -1,5 +1,6 @@
 param (
-  [string] $shortver = "99.99.99"
+  [string] $shortver = "99.99.99",
+  [string] $branch = "dev"
 )
 
 $ErrorActionPreference = "Stop"

--- a/ci/win-x64/build.ps1
+++ b/ci/win-x64/build.ps1
@@ -1,9 +1,14 @@
 param (
-  [string] $shortver = "99.99.99"
+  [string] $shortver = "99.99.99",
+  [string] $branch = "dev"
 )
 
 $ErrorActionPreference = "Stop"
 Push-Location "$PSScriptRoot/../../"
+
+if ($branch -ne "main") {
+    $shortver = "$shortver-$branch"
+}
 
 . "./ci/build-deps.ps1"
 


### PR DESCRIPTION
This PR includes the branch name as a suffix on build versions, so that we can better identify pushes to the `sqelf-ci` image as coming from the `dev` or `main` branches.